### PR TITLE
create FSSuffixedProperties functions with tests

### DIFF
--- a/src/__tests__/FSSuffixedProperties.test.ts
+++ b/src/__tests__/FSSuffixedProperties.test.ts
@@ -1,8 +1,95 @@
-import { getSuffixStringFromSimpleObject } from '../FullStoryConfig';
+import { FSSuffixedProperties } from '../utils/FSSuffixedProperties';
 
-describe('Test getSuffixStringFromSimpleObject', () => {
-  test('Correct Date suffix', () => {
-    const validDate = new Date();
-    expect(getSuffixStringFromSimpleObject(validDate)).toBe('_date');
+describe('FSSuffixedProperties', () => {
+  const fsSuffixedProperties = new FSSuffixedProperties();
+
+  describe('Test getSuffixStringFromSimpleObject()', () => {
+    test('Should return correct Date suffix', () => {
+      const validDate = new Date();
+      expect(
+        fsSuffixedProperties.getSuffixStringFromSimpleObject(validDate)
+      ).toBe('_date');
+    });
+    test('Should return correct String suffix', () => {
+      expect(
+        fsSuffixedProperties.getSuffixStringFromSimpleObject('sample string')
+      ).toBe('_str');
+    });
+    test('Should return correct Boolean suffix', () => {
+      expect(fsSuffixedProperties.getSuffixStringFromSimpleObject(true)).toBe(
+        '_bool'
+      );
+    });
+    test('Should return correct Float suffix', () => {
+      expect(fsSuffixedProperties.getSuffixStringFromSimpleObject(3.14)).toBe(
+        '_real'
+      );
+    });
+    test('Should return correct Integer suffix', () => {
+      expect(fsSuffixedProperties.getSuffixStringFromSimpleObject(3)).toBe(
+        '_int'
+      );
+    });
+    test('Should return empty suffix from empty object', () => {
+      expect(fsSuffixedProperties.getSuffixStringFromSimpleObject({})).toBe('');
+    });
+  });
+
+  describe('Test addSimpleObject()', () => {
+    beforeEach(() => {
+      fsSuffixedProperties.suffixedProperties = {};
+    });
+
+    test('Should add simple string object', () => {
+      const key = 'input.key_str';
+      const val = 'val';
+      fsSuffixedProperties.addSimpleObject(key, val);
+
+      expect(fsSuffixedProperties.suffixedProperties).toEqual({ [key]: val });
+    });
+
+    test('Should add duplicate simple string object', () => {
+      const key = 'input.key_str';
+      const val = 'val';
+      const val2 = 'val2';
+      const val3 = 'val3';
+      fsSuffixedProperties.addSimpleObject(key, val);
+      fsSuffixedProperties.addSimpleObject(key, val2);
+      fsSuffixedProperties.addSimpleObject(key, val3);
+
+      expect(fsSuffixedProperties.suffixedProperties).toEqual({
+        [key]: [val, val2, val3],
+      });
+    });
+  });
+
+  describe('Test pluralizeAllArrayKeys()', () => {
+    beforeEach(() => {
+      fsSuffixedProperties.suffixedProperties = {};
+    });
+
+    test('Should not pluralize', () => {
+      const key = 'input.key_str';
+      const val = 'val';
+      fsSuffixedProperties.addSimpleObject(key, val);
+      fsSuffixedProperties.pluralizeAllArrayKeys();
+
+      expect(fsSuffixedProperties.suffixedProperties).toEqual({ [key]: val });
+    });
+
+    test('Should pluralize', () => {
+      const key = 'input.key_str';
+      const val = 'val';
+      const val2 = 'val2';
+      const val3 = 'val3';
+      fsSuffixedProperties.addSimpleObject(key, val);
+      fsSuffixedProperties.addSimpleObject(key, val2);
+      fsSuffixedProperties.addSimpleObject(key, val3);
+      fsSuffixedProperties.pluralizeAllArrayKeys();
+
+      expect(fsSuffixedProperties.suffixedProperties).toEqual({
+        ['input.key_strs']: [val, val2, val3],
+      });
+    });
   });
 });

--- a/src/utils/FSSuffixedProperties.ts
+++ b/src/utils/FSSuffixedProperties.ts
@@ -1,0 +1,44 @@
+export class FSSuffixedProperties {
+  suffixedProperties: { [key: string]: any } = {};
+
+  getSuffixStringFromSimpleObject(item: any): String {
+    let suffix = '';
+
+    if (!isNaN(item) && !isNaN(parseFloat(item))) {
+      if (Number.isInteger(item)) {
+        suffix = '_int';
+      } else {
+        suffix = '_real';
+      }
+    } else if (item === true || item === false) {
+      suffix = '_bool';
+    } else if (Object.prototype.toString.call(item) === '[object Date]') {
+      suffix = '_date';
+    } else if (typeof item === 'string' || item instanceof String) {
+      suffix = '_str';
+    }
+
+    return suffix;
+  }
+
+  addSimpleObject(key: string, obj: Object) {
+    if (!!this.suffixedProperties[key]) {
+      if (Array.isArray(this.suffixedProperties[key])) {
+        this.suffixedProperties[key].push(obj);
+      } else {
+        this.suffixedProperties[key] = [this.suffixedProperties[key], obj];
+      }
+    } else {
+      this.suffixedProperties[key] = obj;
+    }
+  }
+
+  pluralizeAllArrayKeys() {
+    for (const key in this.suffixedProperties) {
+      if (Array.isArray(this.suffixedProperties[key])) {
+        this.suffixedProperties[key + 's'] = this.suffixedProperties[key];
+        delete this.suffixedProperties[key];
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the first PR on the FullStory Segment plugin. Previous commits were to set up the placeholder functions and tests and to make sure the example project is correctly connected to the plugin. Feel free to review my setup outside of the bounds of this PR.

This plugin aims to mimic the behavior of the native [iOS](https://github.com/fullstorydev/fullstory-segment-middleware-ios/blob/master/FullStoryMiddleware/FSSuffixedProperties.m) and [Android](https://github.com/fullstorydev/fullstory-segment-middleware-android/blob/master/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FSSuffixedProperties.java) plugins. I've implemented three helper functions for class `FSSuffixedProperties` and set up unit tests based on their iOS and Android counterparts.

The aim of this class is to flatten deep objects and process them to be searchable within FS events.